### PR TITLE
Adjusts app config to prevent django breaking.

### DIFF
--- a/wagtailextraicons/__init__.py
+++ b/wagtailextraicons/__init__.py
@@ -1,1 +1,2 @@
-__version__ = '0.1.6'
+__version__ = '0.1.7'
+default_app_config = 'wagtailextraicons.apps.WagtailExtraIconsConfig'

--- a/wagtailextraicons/apps.py
+++ b/wagtailextraicons/apps.py
@@ -2,7 +2,7 @@ from django.apps import AppConfig
 
 
 class WagtailExtraIconsConfig(AppConfig):
-    name = 'wagtail_extra_icons'
+    name = 'wagtailextraicons'
 
     def ready(self):
         pass


### PR DESCRIPTION
Django is throwing an error when AppConfig is named with underscores. This pr resolves that.

<img width="1131" alt="Screen Shot 2021-12-14 at 11 21 12 AM" src="https://user-images.githubusercontent.com/1817298/145899024-32e5be24-1805-4ae2-a741-1fe1750832e8.png">
